### PR TITLE
Ee 1082 update enverus endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Welcome to your new gem! In this directory, you'll find the files you need to be
 
 TODO: Delete this and the text above, and describe your gem
 
+## Enverus API Documentation
+
+The endpoints that are used in this gem are not publicly documented as Enverus has built
+a API specific for FundThrough.
+
+[Documentation for V1 and V2](https://docs.google.com/document/d/1hclQzZH_VeItW4xC8e68RhdD70dWn6l7/edit?usp=sharing&ouid=104023789344514089935&rtpof=true&sd=true)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/open_invoice/client.rb
+++ b/lib/open_invoice/client.rb
@@ -31,9 +31,5 @@ module OpenInvoice
     def buyer
       @buyer ||= ::OpenInvoice::Entities::Buyer.new(supplier_uuid)
     end
-
-    def payment
-      @buyer ||= ::OpenInvoice::Entities::Payment.new(supplier_uuid)
-    end
   end
 end

--- a/lib/open_invoice/configure.rb
+++ b/lib/open_invoice/configure.rb
@@ -6,6 +6,9 @@ module OpenInvoice
 
     attr_writer(*KEYS)
 
+    VERSION_1 = "v1".freeze
+    VERSION_2 = "v2".freeze
+
     def configure
       yield self
       self

--- a/lib/open_invoice/configure.rb
+++ b/lib/open_invoice/configure.rb
@@ -6,7 +6,6 @@ module OpenInvoice
 
     attr_writer(*KEYS)
 
-    VERSION_1 = "v1".freeze
     VERSION_2 = "v2".freeze
 
     def configure

--- a/lib/open_invoice/entities/buyer.rb
+++ b/lib/open_invoice/entities/buyer.rb
@@ -2,7 +2,7 @@ module OpenInvoice
   module Entities
     class Buyer < Base
       def index(opts = {})
-        request(:get, "/supplier/#{supplier_uuid}/buyers", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_2}/supplier/#{supplier_uuid}/buyers", opts)
       end
     end
   end

--- a/lib/open_invoice/entities/invoice.rb
+++ b/lib/open_invoice/entities/invoice.rb
@@ -4,15 +4,15 @@ module OpenInvoice
   module Entities
     class Invoice < Base
       def index(opts = {})
-        request(:get, "/supplier/#{supplier_uuid}/invoices/page", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{supplier_uuid}/invoices/page", opts)
       end
 
       def attachments(invoice_id, opts = {})
-        request(:get, "/supplier/#{supplier_uuid}/invoices/#{invoice_id}/attachments", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{supplier_uuid}/invoices/#{invoice_id}/attachments", opts)
       end
 
       def download_attachment(invoice_id, attachment_id, file_path, opts)
-        attachment_url = "/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/attachments/#{attachment_id}"
+        attachment_url = "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/attachments/#{attachment_id}"
         dirname = File.dirname(file_path)
         opts[:stream_body] = true
         FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
@@ -39,7 +39,7 @@ module OpenInvoice
       end
 
       def history(invoice_id, opts = {})
-        request(:get, "/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/history", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/history", opts)
       end
     end
   end

--- a/lib/open_invoice/entities/invoice.rb
+++ b/lib/open_invoice/entities/invoice.rb
@@ -4,15 +4,15 @@ module OpenInvoice
   module Entities
     class Invoice < Base
       def index(opts = {})
-        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{supplier_uuid}/invoices/page", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_2}/supplier/#{supplier_uuid}/invoices/page", opts)
       end
 
       def attachments(invoice_id, opts = {})
-        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{supplier_uuid}/invoices/#{invoice_id}/attachments", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_2}/supplier/#{supplier_uuid}/invoices/#{invoice_id}/attachments", opts)
       end
 
       def download_attachment(invoice_id, attachment_id, file_path, opts)
-        attachment_url = "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/attachments/#{attachment_id}"
+        attachment_url = "/#{OpenInvoice::Configure::VERSION_2}/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/attachments/#{attachment_id}"
         dirname = File.dirname(file_path)
         opts[:stream_body] = true
         FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
@@ -39,7 +39,7 @@ module OpenInvoice
       end
 
       def history(invoice_id, opts = {})
-        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/history", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_2}/supplier/#{@supplier_uuid}/invoices/#{invoice_id}/history", opts)
       end
     end
   end

--- a/lib/open_invoice/entities/payment.rb
+++ b/lib/open_invoice/entities/payment.rb
@@ -1,9 +1,0 @@
-module OpenInvoice
-  module Entities
-    class Payment < Base
-      def index(opts = {})
-        request(:get, "/supplier/#{supplier_uuid}/payment", opts)
-      end
-    end
-  end
-end

--- a/lib/open_invoice/entities/supplier.rb
+++ b/lib/open_invoice/entities/supplier.rb
@@ -2,7 +2,7 @@ module OpenInvoice
   module Entities
     class Supplier < Base
       def index(opts = {})
-        request(:get, "/supplier/#{supplier_uuid}", opts)
+        request(:get, "/#{OpenInvoice::Configure::VERSION_2}/supplier/#{supplier_uuid}", opts)
       end
     end
   end

--- a/lib/open_invoice/entities/user.rb
+++ b/lib/open_invoice/entities/user.rb
@@ -8,7 +8,7 @@ module OpenInvoice
       end
 
       def get
-        request(:get, "/users/#{user_uuid}")
+        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/users/#{user_uuid}")
       end
     end
   end

--- a/lib/open_invoice/entities/user.rb
+++ b/lib/open_invoice/entities/user.rb
@@ -8,7 +8,7 @@ module OpenInvoice
       end
 
       def get
-        request(:get, "/#{OpenInvoice::Configure::VERSION_1}/users/#{user_uuid}")
+        request(:get, "/#{OpenInvoice::Configure::VERSION_2}/users/#{user_uuid}")
       end
     end
   end


### PR DESCRIPTION
## Ticket
[EE-1082](https://fundthrough.atlassian.net/browse/EE-1082)

## Changes
- Updating the endpoints to use versioning
- Removing the payment endpoint as it has been deprecated by Enverus & we aren't using it anywhere

NOTE: a new base_url is also being used. It has been set for aux1 [here](https://us-east-1.console.aws.amazon.com/systems-manager/parameters/%252Faux1%252Fapp%252Fbraavos%252FOPEN_INVOICE_BASE_URI/description?region=us-east-1&tab=Table#list_parameter_filters=Name:Contains:open_invoice_base_uri)

Note: the base_url will need to be updated for the other test environments & production

Enverus API docs [here](https://docs.google.com/document/d/1hclQzZH_VeItW4xC8e68RhdD70dWn6l7/edit)

## Definition of Done

- [ ] Pull request is up to date with the destination branch
- [ ] Commits were squashed
- [ ] All Tests are passing
- [ ] At least one code review
- [ ] Screen-Review passed and logged.


[EE-1082]: https://fundthrough.atlassian.net/browse/EE-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ